### PR TITLE
Improved handling of docker compose arguments

### DIFF
--- a/src/commands/docker.ts
+++ b/src/commands/docker.ts
@@ -19,8 +19,8 @@ exports.handler = function (argv: { [x: string]: any; root: string; debug: any; 
 
   // Hack to parse the commands that should be sendt to docker.
   let options = process.argv.splice(2);
-  let cmd = '';
 
+  const composeArguments = [];
   for (let i = 0; i < options.length; i++) {
     switch (options[i]) {
       case "--debug":
@@ -35,7 +35,7 @@ exports.handler = function (argv: { [x: string]: any; root: string; debug: any; 
         continue;
 
       default:
-        cmd += ' ' + options[i];
+        composeArguments.push(options[i]);
     }
   }
 
@@ -43,6 +43,6 @@ exports.handler = function (argv: { [x: string]: any; root: string; debug: any; 
     docker.info(argv.debug, env, argv.root);
   }
   else {
-    docker.exec(argv.debug, env, argv.root, argv.compose, cmd)
+    docker.exec(argv.debug, env, argv.root, argv.compose, composeArguments)
   }
 }

--- a/src/modules/docker.ts
+++ b/src/modules/docker.ts
@@ -1,9 +1,10 @@
 'use strict'
 
-import {execSync} from "child_process"
+import {execFileSync} from "child_process"
 import * as envfile from "envfile"
 import * as fs from "fs"
 import * as yaml from "js-yaml"
+import Utils from "./utils";
 
 /**
  * ComposerYAML interface.
@@ -42,35 +43,39 @@ export default class Docker {
 	 *   The root path to execute the command in.
 	 * @param compose
 	 *   The composer binary.
-	 * @param inputCmd
-	 *   The commands to parse to docker compose.
+	 * @param composeArguments
+	 *   The commands to pass to docker compose.
 	 */
-	public exec(debug: boolean, env: string, root: string, compose: string, inputCmd: string)
+	public exec(debug: boolean, env: string, root: string, compose: string, composeArguments: string[])
 	{
-		let cmd = compose + ' --env-file ' + env + ' ';
+		const args = [
+			'--env-file', env
+		]
 
 		// Get yml files from .env file.
 		let content = fs.readFileSync(root + '/' + env);
 		let json = envfile.parse(content.toString());
 		if (!json.hasOwnProperty('COMPOSE_FILES')) {
-			cmd += '-f docker-compose.server.yml '
-		}
-		else {
-			let files = json.COMPOSE_FILES.split(",");
-			files.forEach(function (element: string) {
-				cmd += '-f ' + element + ' ';
-			});
+			json.COMPOSE_FILES = 'docker-compose.server.yml'
 		}
 
-		// Add command string.
-		cmd += inputCmd;
+		let files = json.COMPOSE_FILES.split(",");
+		files.forEach(function (element: string) {
+			args.push('--file')
+			args.push(element)
+		});
+
+		for (var a of composeArguments) {
+			args.push(a)
+		}
 
 		if (debug) {
-			console.log(cmd);
+			const utils = new Utils()
+			console.log([compose, ...args].map(s => utils.shellEscape(s)).join(' '));
 		}
 		else {
 			try {
-				execSync(cmd, {encoding: 'utf8', cwd: root, stdio: 'inherit'});
+				execFileSync(compose, args, {encoding: 'utf8', cwd: root, stdio: 'inherit'});
 			} catch (err) {
 				if (err instanceof Error) {
 					console.error(err.message);

--- a/src/modules/utils.ts
+++ b/src/modules/utils.ts
@@ -52,4 +52,17 @@ export default class Utils {
   public getFiles (source: string) {
     return fs.readdirSync(source).map((name: string) => path.join(source, name)).filter(this.isFile);
   }
+
+  /**
+   * Escape shell argument.
+   *
+   * @see https://github.com/nodejs/node/issues/34840#issuecomment-677402567
+   *
+   * @param value
+   */
+  public shellEscape(s: string) {
+    if (s === '') return `''`;
+    if (!/[^%+,-.\/:=@_0-9A-Za-z]/.test(s)) return s;
+    return `'` + s.replace(/'/g, `'"'`) + `'`;
+  }
 }


### PR DESCRIPTION
#### Description

Improves handling of docker compose arguments by not using string concatenation to send them to `execSync`.

Stuff like 

```sh
itkdev-docker-compose-server exec phpfpm php -r 'echo 1, 2, 3;'
```

will now work as expected.

#### Additional comments or questions

I cannot find documentation on how to develop and test this nice project. Do you have any guidelines or tips on how to build (for test) and run the command during development?
